### PR TITLE
Tokens from the Wrapped Asset Bridge

### DIFF
--- a/tokenlist/tokenlist.json
+++ b/tokenlist/tokenlist.json
@@ -23,6 +23,30 @@
         },
         {
             "chainId": 42793,
+            "address": "0xfc24f770F94edBca6D6f885E12d4317320BcB401",
+            "decimals": 18,
+            "name": "Wrapped Ether",
+            "symbol": "WETH",
+            "logoURI": "https://assets.coingecko.com/coins/images/2518/standard/weth.png?1696503332"
+        },
+        {
+            "chainId": 42793,
+            "address": "0xaA40A1cc1561c584B675cbD12F1423A32E2a0d8C",
+            "decimals": 18,
+            "name": "Wrapped BNB",
+            "symbol": "WBNB",
+            "logoURI": "https://assets.coingecko.com/coins/images/12591/standard/binance-coin-logo.png?1696512401"
+        },
+        {
+            "chainId": 42793,
+            "address": "0xe820995cD39B6E09EAa7e4e16337184b4A61B644",
+            "decimals": 18,
+            "name": "Wrapped AVAX",
+            "symbol": "WAVAX",
+            "logoURI": "https://assets.coingecko.com/coins/images/15075/standard/wrapped-avax.png?1696514734"
+        },
+        {
+            "chainId": 42793,
             "address": "0x2C03058C8AFC06713be23e58D2febC8337dbfE6A",
             "decimals": 6,
             "name": "Tether USD",
@@ -39,11 +63,19 @@
         },
         {
             "chainId": 42793,
-            "address": "0xfc24f770F94edBca6D6f885E12d4317320BcB401",
+            "address": "0xBBD1F50A212357067318a84179892684e1Ac5181",
             "decimals": 18,
-            "name": "Wrapped Ether",
-            "symbol": "WETH",
-            "logoURI": "https://assets.coingecko.com/coins/images/31019/standard/download_%2817%29.png?1696529855"
+            "name": "SHIBA INU",
+            "symbol": "SHIB",
+            "logoURI": "https://assets.coingecko.com/coins/images/11939/standard/shiba.png?1696511800"
+        },
+        {
+            "chainId": 42793,
+            "address": "0xbFc94CD2B1E55999Cfc7347a9313e88702B83d0F",
+            "decimals": 8,
+            "name": "Wrapped BTC",
+            "symbol": "WBTC",
+            "logoURI": "https://assets.coingecko.com/coins/images/7598/standard/wrapped_bitcoin_wbtc.png?1696507857"
         },
         {
             "chainId": 42793,


### PR DESCRIPTION
Hey guys, I just added all the tokens from the Wrapped Asset Bridge on Etherlink. You can verify them on the explorer they are all the official ones (unless I have done a mistake while copy/pasting). I think this is really important to have them as all the first liquidity on Etherlink will come from these tokens!